### PR TITLE
Fix typo in email mismatch error message

### DIFF
--- a/server/avalon-server.ts
+++ b/server/avalon-server.ts
@@ -69,7 +69,7 @@ export function loginUser(data: LoginData, uid: string): Promise<void> {
     return txn.get(userDocRef).then(function(userDoc) {
       if (userDoc.exists) {
         if (userDoc.get('email') != emailAddr) {
-          throw new AvalonError(429, 'Mismatched emails: ' + userDoc.get('emails') + ' and ' + emailAddr);
+          throw new AvalonError(429, 'Mismatched emails: ' + userDoc.get('email') + ' and ' + emailAddr);
         }
         const lobbyName = userDoc.get('lobby') as string | undefined;
         if (lobbyName) {


### PR DESCRIPTION
## Summary
Fixed a typo in the error message for email mismatch validation during user login.

## Changes
- Corrected `userDoc.get('emails')` to `userDoc.get('email')` in the error message
  - The field being compared is `email` (singular), not `emails` (plural)
  - This ensures the error message displays the actual mismatched email value instead of undefined

## Details
The error message was attempting to access a non-existent `emails` field when constructing the mismatch error. This would have resulted in an unclear error message showing `undefined` instead of the actual email value from the user document. The fix aligns the field name with the actual document schema and the field being validated on line 71.

https://claude.ai/code/session_01K9tFdpfANA4x3Qx84SdAK6