### PR TITLE
Refactor auth middleware to use async/await and improve error handling

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -20,17 +20,21 @@ app.use(express.static(path.join(__dirname, 'dist')));
 
 const router = promiseRouter();
 
-router.use(function(req: AuthenticatedRequest, _res: Response, next: NextFunction) {
+router.use(async function(req: AuthenticatedRequest, res: Response, next: NextFunction) {
   const idToken = req.get('X-Avalon-Auth');
   if (!idToken) {
-    throw new Error(`No auth info in request: ${req.method} ${req.path}`);
+    res.status(401).json({ message: `No auth info in request: ${req.method} ${req.path}` });
+    return;
   }
 
-  getAuth().verifyIdToken(idToken).then(function(decodedToken) {
+  try {
+    const decodedToken = await getAuth().verifyIdToken(idToken);
     req.uid = decodedToken.uid;
     console.log('Request', req.method, req.path, req.uid, JSON.stringify(req.body));
     next();
-  });
+  } catch {
+    res.status(401).json({ message: 'Invalid or expired auth token' });
+  }
 });
 
 router.post('/login', (req: AuthenticatedRequest, res: Response) => {


### PR DESCRIPTION
## Summary
Refactored the authentication middleware to use modern async/await syntax instead of promise chains, and improved error handling by returning proper HTTP 401 responses instead of throwing errors.

## Key Changes
- Converted middleware function to `async` and replaced `.then()` promise chain with `await` syntax
- Changed error handling from throwing exceptions to returning HTTP 401 responses with JSON error messages
- Added explicit error handling for token verification failures with a try/catch block
- Improved error responses to be consistent and client-friendly (JSON format with descriptive messages)

## Implementation Details
- When no auth token is provided in the `X-Avalon-Auth` header, the middleware now returns a 401 status with a descriptive message instead of throwing an error
- Token verification errors (invalid or expired tokens) are now caught and return a 401 status with an appropriate error message
- The middleware properly returns after sending error responses to prevent further processing
- This change maintains the same authentication flow while providing better error handling and more standard HTTP response patterns

https://claude.ai/code/session_01Lr6gxcrKiscrrLhxmjVrUe