### PR TITLE
Potential fix for code scanning alert no. 11: Use of externally-controlled format string

### DIFF
--- a/server/avalon-server.ts
+++ b/server/avalon-server.ts
@@ -647,7 +647,7 @@ function recordVote(
       }
 
       if (voteValidator && !voteValidator(name, vote, secretDoc)) {
-        console.log(name, 'is not allowed to vote', vote, ', switching to ', !vote);
+        console.log('%s is not allowed to vote %s, switching to %s', name, String(vote), String(!vote));
         vote = !vote;
       }
 

--- a/server/avalon-server.ts
+++ b/server/avalon-server.ts
@@ -116,7 +116,7 @@ export function joinLobby(data: JoinLobbyData, uid: string): Promise<{ lobby: st
       const currentLobby = userDoc.get('lobby') as string | undefined;
       if (currentLobby != null) {
         if (currentLobby != data.lobby) {
-          console.log(uid, 'currently in', userDoc.get('lobby'), 'tried to join', data.lobby);
+          console.log('%s currently in %s tried to join %s', uid, userDoc.get('lobby'), data.lobby);
         }
         return {
           lobby: userDoc.get('lobby') as string,
@@ -636,7 +636,7 @@ function recordVote(
       const uid = users[name].uid;
 
       if (requestUid != uid) {
-        console.log(name, 'is', uid, 'but request came from', requestUid);
+        console.log('%s is %s but request came from %s', name, uid, requestUid);
         throw new AvalonError(403, 'You are not who you say you are');
       }
 
@@ -647,7 +647,7 @@ function recordVote(
       }
 
       if (voteValidator && !voteValidator(name, vote, secretDoc)) {
-        console.log('%s is not allowed to vote %s, switching to %s', name, String(vote), String(!vote));
+        console.log('%s is not allowed to vote %s, switching to %s', name, vote, !vote);
         vote = !vote;
       }
 


### PR DESCRIPTION
Potential fix for [https://github.com/georgyo/avalon/security/code-scanning/11](https://github.com/georgyo/avalon/security/code-scanning/11)

General fix approach: When calling logging or formatting functions that treat the first argument as a format string (`console.log`, `util.format`, etc.), never let that first argument be directly derived from untrusted input. Instead, use a constant format string with `%s` placeholders (or template literals that are not interpreted as format strings), and pass untrusted data as subsequent arguments.

Concrete fix here: On line 650 of `server/avalon-server.ts`, the first argument to `console.log` is `name`, which is user-controlled. We should change this call so that the first argument is a constant string, and `name` is passed in as a later argument. This preserves all existing information in the log while eliminating the format-string risk.

Specifically, replace:

```ts
console.log(name, 'is not allowed to vote', vote, ', switching to ', !vote);
```

with a call like:

```ts
console.log('%s is not allowed to vote %s, switching to %s', name, vote, !vote);
```

This uses a fixed format string (`'%s is not allowed to vote %s, switching to %s'`) and passes `name`, `vote`, and `!vote` as safe substitution values. No new imports or helper methods are required, and no other lines need to change. This single change addresses all alert variants at this location since they share the same root cause (tainted `name` used as the format string).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
