### PR TITLE
Potential fix for code scanning alert no. 1: Loop bound injection

### DIFF
--- a/server/avalon-server.ts
+++ b/server/avalon-server.ts
@@ -498,7 +498,7 @@ export function startGame(data: StartGameData, uid: string): Promise<boolean> {
     throw new AvalonError(400, 'Bad player list ' + data.playerList);
   }
 
-  if (!data.roles || !data.roles.every(role => ROLES.find(r => r.name == role))) {
+  if (!Array.isArray(data.roles) || !data.roles.every(role => ROLES.find(r => r.name == role))) {
     throw new AvalonError(400, 'Bad roles ' + data.roles);
   }
 
@@ -563,6 +563,9 @@ export function startGame(data: StartGameData, uid: string): Promise<boolean> {
 }
 
 export function proposeTeam(data: TeamProposalData, uid: string): Promise<void> {
+  if (!Array.isArray(data.team)) {
+    throw new AvalonError(400, 'Bad team: must be an array');
+  }
   data.team = _.uniq(data.team);
 
   const lobbyDocRef = db.collection('lobbies').doc(data.lobby);

--- a/server/avalon-server.ts
+++ b/server/avalon-server.ts
@@ -491,10 +491,11 @@ function endGameTxn(
 
 export function startGame(data: StartGameData, uid: string): Promise<boolean> {
 
-  if (!data.playerList ||
+  if (!Array.isArray(data.playerList) ||
     data.playerList.length < 5  ||
-    data.playerList.length > 10) {
-    throw new AvalonError(400, 'Bad player list length' + data.playerList);
+    data.playerList.length > 10 ||
+    !data.playerList.every(p => typeof p === 'string')) {
+    throw new AvalonError(400, 'Bad player list ' + data.playerList);
   }
 
   if (!data.roles || !data.roles.every(role => ROLES.find(r => r.name == role))) {


### PR DESCRIPTION
Potential fix for [https://github.com/georgyo/avalon/security/code-scanning/1](https://github.com/georgyo/avalon/security/code-scanning/1)

In general, to fix loop bound injection on `teamList` (and thus `playerList`), we must ensure that the user-controlled value is a real array with a strictly bounded length before any code paths that depend on its `.length` or that pass it into utilities (like Lodash) that iterate based on `.length`. Since all flows to `assignRoles` and `makeMissions` go through `startGame`, we can centralize the validation there.

Concretely, the safest minimal change is:

- In `startGame`, before using `data.playerList`, verify:
  - `Array.isArray(data.playerList)` is true.
  - Its `.length` is between 5 and 10 (already done).
  - Every element is a string (since it’s used as a player name).
- Optionally, normalize it into a new array (e.g., `const playerList = data.playerList.slice();`) and use that variable everywhere instead of the raw `data.playerList`, but that’s not strictly necessary once we have the type and length check.

This keeps existing behavior (still requires 5–10 players, same lobby-user checks, same role assignment logic), but adds an explicit guard that `playerList` is an actual array with small size. That immediately bounds the `.length` seen by Lodash when it iterates over `teamList` and prevents constructing pathological objects such as `{ length: 1e100 }`. No changes are needed in `assignRoles` itself for correctness; it already assumes `playerList: string[]`. We’ll adjust the validation block around lines 494–498 in `server/avalon-server.ts` to add the array and element-type checks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
