### PR TITLE
Potential fix for code scanning alert no. 9: Prototype-polluting assignment

### DIFF
--- a/server/avalon-server.ts
+++ b/server/avalon-server.ts
@@ -693,10 +693,22 @@ export function voteTeam(data: VoteData, uid: string): Promise<void> {
   const lobbyDocRef = db.collection('lobbies').doc(data.lobby);
   const secretDocRef = lobbyDocRef.collection('roles').doc(SECRET_STATE_DOC_NAME);
 
-  return recordVote(data.name, uid, data.lobby, missionIndex,
-    proposalIndex, data.vote, 'PROPOSAL_VOTE', 'PENDING',
-    (_game, _mission, proposal) => proposal.votes,
-    (secretVotes) => secretVotes.proposal).then(function() {
+  // Validate bounds before calling recordVote to prevent runtime errors
+  return lobbyDocRef.get().then(function(lobbyDoc) {
+    const game = lobbyDoc.get('game') as Game;
+    if (!game || !Array.isArray(game.missions) || missionIndex >= game.missions.length) {
+      throw new AvalonError(400, 'Mission not found');
+    }
+    const mission = game.missions[missionIndex];
+    if (!Array.isArray(mission.proposals) || proposalIndex >= mission.proposals.length) {
+      throw new AvalonError(400, 'Proposal not found');
+    }
+
+    return recordVote(data.name, uid, data.lobby, missionIndex,
+      proposalIndex, data.vote, 'PROPOSAL_VOTE', 'PENDING',
+      (_game, _mission, proposal) => proposal.votes,
+      (secretVotes) => secretVotes.proposal);
+  }).then(function() {
     return db.runTransaction(function(txn) {
       return Promise.all([
         txn.get(lobbyDocRef),
@@ -759,12 +771,24 @@ export function doMission(data: VoteData, uid: string): Promise<void> {
     throw new AvalonError(400, `Invalid proposal index: ${data.proposal}`);
   }
 
-  return recordVote(data.name, uid, data.lobby, missionIndex,
-    proposalIndex, data.vote, 'MISSION_VOTE', 'APPROVED',
-    (_game, mission, _proposal) => mission.team,
-    (secretVotes) => secretVotes.mission[missionIndex],
-    ((name, vote, secretDoc) => vote || (secretDoc.get('roles') as Record<string, PlayerRole>)[name].team == 'evil')
-    ).then(function() {
+  // Validate bounds before calling recordVote to prevent runtime errors
+  return lobbyDocRef.get().then(function(lobbyDoc) {
+    const game = lobbyDoc.get('game') as Game;
+    if (!game || !Array.isArray(game.missions) || missionIndex >= game.missions.length) {
+      throw new AvalonError(400, 'Mission not found');
+    }
+    const mission = game.missions[missionIndex];
+    if (!Array.isArray(mission.proposals) || proposalIndex >= mission.proposals.length) {
+      throw new AvalonError(400, 'Proposal not found');
+    }
+
+    return recordVote(data.name, uid, data.lobby, missionIndex,
+      proposalIndex, data.vote, 'MISSION_VOTE', 'APPROVED',
+      (_game, mission, _proposal) => mission.team,
+      (secretVotes) => secretVotes.mission[missionIndex],
+      ((name, vote, secretDoc) => vote || (secretDoc.get('roles') as Record<string, PlayerRole>)[name].team == 'evil')
+    );
+  }).then(function() {
     return db.runTransaction(function(txn) {
       return Promise.all([
         txn.get(lobbyDocRef),

--- a/server/avalon-server.ts
+++ b/server/avalon-server.ts
@@ -772,11 +772,11 @@ export function doMission(data: VoteData, uid: string): Promise<void> {
           function([lobbyDoc, secretDoc]) {
       const game = lobbyDoc.get('game') as Game;
       if (!game || !Array.isArray(game.missions) || missionIndex >= game.missions.length) {
-        throw new AvalonError('Mission not found', 400);
+        throw new AvalonError(400, 'Mission not found');
       }
       const mission = game.missions[missionIndex];
       if (!Array.isArray(mission.proposals) || proposalIndex >= mission.proposals.length) {
-        throw new AvalonError('Proposal not found', 400);
+        throw new AvalonError(400, 'Proposal not found');
       }
       const proposal = mission.proposals[proposalIndex];
       const votes = secretDoc.get('votes') as SecretVotes;

--- a/server/avalon-server.ts
+++ b/server/avalon-server.ts
@@ -720,10 +720,19 @@ export function doMission(data: VoteData, uid: string): Promise<void> {
   const lobbyDocRef = db.collection('lobbies').doc(data.lobby);
   const secretDocRef = lobbyDocRef.collection('roles').doc(SECRET_STATE_DOC_NAME);
 
-  return recordVote(data.name, uid, data.lobby, data.mission,
-    data.proposal, data.vote, 'MISSION_VOTE', 'APPROVED',
+  const missionIndex = Number(data.mission);
+  const proposalIndex = Number(data.proposal);
+  if (!Number.isInteger(missionIndex) || missionIndex < 0) {
+    throw new AvalonError(`Invalid mission index: ${data.mission}`, 400);
+  }
+  if (!Number.isInteger(proposalIndex) || proposalIndex < 0) {
+    throw new AvalonError(`Invalid proposal index: ${data.proposal}`, 400);
+  }
+
+  return recordVote(data.name, uid, data.lobby, missionIndex,
+    proposalIndex, data.vote, 'MISSION_VOTE', 'APPROVED',
     (_game, mission, _proposal) => mission.team,
-    (secretVotes) => secretVotes.mission[data.mission],
+    (secretVotes) => secretVotes.mission[missionIndex],
     ((name, vote, secretDoc) => vote || (secretDoc.get('roles') as Record<string, PlayerRole>)[name].team == 'evil')
     ).then(function() {
     return db.runTransaction(function(txn) {
@@ -732,21 +741,28 @@ export function doMission(data: VoteData, uid: string): Promise<void> {
         txn.get(secretDocRef)]).then(
           function([lobbyDoc, secretDoc]) {
       const game = lobbyDoc.get('game') as Game;
-      const mission = game.missions[data.mission];
-      const proposal = mission.proposals[data.proposal];
+      if (!game || !Array.isArray(game.missions) || missionIndex >= game.missions.length) {
+        throw new AvalonError('Mission not found', 400);
+      }
+      const mission = game.missions[missionIndex];
+      if (!Array.isArray(mission.proposals) || proposalIndex >= mission.proposals.length) {
+        throw new AvalonError('Proposal not found', 400);
+      }
+      const proposal = mission.proposals[proposalIndex];
       const votes = secretDoc.get('votes') as SecretVotes;
 
       if (mission.state != 'PENDING') {
         return;
       }
 
-      if (Object.keys(votes.mission[data.mission]).length != mission.teamSize) {
+      if (!votes || !votes.mission || !votes.mission[missionIndex] ||
+          Object.keys(votes.mission[missionIndex]).length != mission.teamSize) {
         return;
       }
 
       mission.team = proposal.team;
 
-      mission.numFails = Object.values(votes.mission[data.mission]).filter(v => !v).length;
+      mission.numFails = Object.values(votes.mission[missionIndex]).filter(v => !v).length;
 
       if (mission.numFails < mission.failsRequired) {
         mission.state = 'SUCCESS';
@@ -767,7 +783,9 @@ export function doMission(data: VoteData, uid: string): Promise<void> {
         }
       } else {
         game.phase = 'TEAM_PROPOSAL';
-        game.missions[data.mission + 1].proposals.push(proposalTemplate(proposal.proposer, game.players));
+        if (missionIndex + 1 < game.missions.length) {
+          game.missions[missionIndex + 1].proposals.push(proposalTemplate(proposal.proposer, game.players));
+        }
       }
       txn.update(lobbyDocRef, 'game', game);
     });

--- a/server/avalon-server.ts
+++ b/server/avalon-server.ts
@@ -645,7 +645,13 @@ function recordVote(
       validateField(lobbyDoc, 'game.phase', gamePhase);
 
       const game = lobbyDoc.get('game') as Game;
+      if (!game || !Array.isArray(game.missions) || missionIdx >= game.missions.length) {
+        throw new AvalonError(400, 'Mission not found');
+      }
       const mission = game.missions[missionIdx];
+      if (!Array.isArray(mission.proposals) || proposalIdx >= mission.proposals.length) {
+        throw new AvalonError(400, 'Proposal not found');
+      }
       const proposal = mission.proposals[proposalIdx];
 
       validateValue(mission.state, 'PENDING', "Mission state");
@@ -693,22 +699,10 @@ export function voteTeam(data: VoteData, uid: string): Promise<void> {
   const lobbyDocRef = db.collection('lobbies').doc(data.lobby);
   const secretDocRef = lobbyDocRef.collection('roles').doc(SECRET_STATE_DOC_NAME);
 
-  // Validate bounds before calling recordVote to prevent runtime errors
-  return lobbyDocRef.get().then(function(lobbyDoc) {
-    const game = lobbyDoc.get('game') as Game;
-    if (!game || !Array.isArray(game.missions) || missionIndex >= game.missions.length) {
-      throw new AvalonError(400, 'Mission not found');
-    }
-    const mission = game.missions[missionIndex];
-    if (!Array.isArray(mission.proposals) || proposalIndex >= mission.proposals.length) {
-      throw new AvalonError(400, 'Proposal not found');
-    }
-
-    return recordVote(data.name, uid, data.lobby, missionIndex,
-      proposalIndex, data.vote, 'PROPOSAL_VOTE', 'PENDING',
-      (_game, _mission, proposal) => proposal.votes,
-      (secretVotes) => secretVotes.proposal);
-  }).then(function() {
+  return recordVote(data.name, uid, data.lobby, missionIndex,
+    proposalIndex, data.vote, 'PROPOSAL_VOTE', 'PENDING',
+    (_game, _mission, proposal) => proposal.votes,
+    (secretVotes) => secretVotes.proposal).then(function() {
     return db.runTransaction(function(txn) {
       return Promise.all([
         txn.get(lobbyDocRef),
@@ -771,24 +765,12 @@ export function doMission(data: VoteData, uid: string): Promise<void> {
     throw new AvalonError(400, `Invalid proposal index: ${data.proposal}`);
   }
 
-  // Validate bounds before calling recordVote to prevent runtime errors
-  return lobbyDocRef.get().then(function(lobbyDoc) {
-    const game = lobbyDoc.get('game') as Game;
-    if (!game || !Array.isArray(game.missions) || missionIndex >= game.missions.length) {
-      throw new AvalonError(400, 'Mission not found');
-    }
-    const mission = game.missions[missionIndex];
-    if (!Array.isArray(mission.proposals) || proposalIndex >= mission.proposals.length) {
-      throw new AvalonError(400, 'Proposal not found');
-    }
-
-    return recordVote(data.name, uid, data.lobby, missionIndex,
-      proposalIndex, data.vote, 'MISSION_VOTE', 'APPROVED',
-      (_game, mission, _proposal) => mission.team,
-      (secretVotes) => secretVotes.mission[missionIndex],
-      ((name, vote, secretDoc) => vote || (secretDoc.get('roles') as Record<string, PlayerRole>)[name].team == 'evil')
-    );
-  }).then(function() {
+  return recordVote(data.name, uid, data.lobby, missionIndex,
+    proposalIndex, data.vote, 'MISSION_VOTE', 'APPROVED',
+    (_game, mission, _proposal) => mission.team,
+    (secretVotes) => secretVotes.mission[missionIndex],
+    ((name, vote, secretDoc) => vote || (secretDoc.get('roles') as Record<string, PlayerRole>)[name].team == 'evil')
+  ).then(function() {
     return db.runTransaction(function(txn) {
       return Promise.all([
         txn.get(lobbyDocRef),
@@ -837,9 +819,11 @@ export function doMission(data: VoteData, uid: string): Promise<void> {
         }
       } else {
         game.phase = 'TEAM_PROPOSAL';
-        if (missionIndex + 1 < game.missions.length) {
-          game.missions[missionIndex + 1].proposals.push(proposalTemplate(proposal.proposer, game.players));
+        const nextMissionIndex = missionIndex + 1;
+        if (nextMissionIndex >= game.missions.length) {
+          throw new AvalonError(500, 'Invariant violated: no next mission available for TEAM_PROPOSAL phase');
         }
+        game.missions[nextMissionIndex].proposals.push(proposalTemplate(proposal.proposer, game.players));
       }
       txn.update(lobbyDocRef, 'game', game);
     });

--- a/server/avalon-server.ts
+++ b/server/avalon-server.ts
@@ -568,6 +568,15 @@ export function proposeTeam(data: TeamProposalData, uid: string): Promise<void> 
   }
   data.team = _.uniq(data.team);
 
+  const missionIndex = Number(data.mission);
+  const proposalIndex = Number(data.proposal);
+  if (!Number.isInteger(missionIndex) || missionIndex < 0) {
+    throw new AvalonError(400, `Invalid mission index: ${data.mission}`);
+  }
+  if (!Number.isInteger(proposalIndex) || proposalIndex < 0) {
+    throw new AvalonError(400, `Invalid proposal index: ${data.proposal}`);
+  }
+
   const lobbyDocRef = db.collection('lobbies').doc(data.lobby);
 
   return db.runTransaction(function(txn) {
@@ -576,8 +585,14 @@ export function proposeTeam(data: TeamProposalData, uid: string): Promise<void> 
       validateField(lobbyDoc, 'game.phase', 'TEAM_PROPOSAL');
 
       const game = lobbyDoc.get('game') as Game;
-      const mission = game.missions[data.mission];
-      const proposal = mission.proposals[data.proposal];
+      if (!game || !Array.isArray(game.missions) || missionIndex >= game.missions.length) {
+        throw new AvalonError(400, 'Mission not found');
+      }
+      const mission = game.missions[missionIndex];
+      if (!Array.isArray(mission.proposals) || proposalIndex >= mission.proposals.length) {
+        throw new AvalonError(400, 'Proposal not found');
+      }
+      const proposal = mission.proposals[proposalIndex];
 
       validateValue(mission.state, 'PENDING', "Mission state");
       validateValue(proposal.state, 'PENDING', 'Proposal state');
@@ -666,11 +681,20 @@ function recordVote(
 }
 
 export function voteTeam(data: VoteData, uid: string): Promise<void> {
+  const missionIndex = Number(data.mission);
+  const proposalIndex = Number(data.proposal);
+  if (!Number.isInteger(missionIndex) || missionIndex < 0) {
+    throw new AvalonError(400, `Invalid mission index: ${data.mission}`);
+  }
+  if (!Number.isInteger(proposalIndex) || proposalIndex < 0) {
+    throw new AvalonError(400, `Invalid proposal index: ${data.proposal}`);
+  }
+
   const lobbyDocRef = db.collection('lobbies').doc(data.lobby);
   const secretDocRef = lobbyDocRef.collection('roles').doc(SECRET_STATE_DOC_NAME);
 
-  return recordVote(data.name, uid, data.lobby, data.mission,
-    data.proposal, data.vote, 'PROPOSAL_VOTE', 'PENDING',
+  return recordVote(data.name, uid, data.lobby, missionIndex,
+    proposalIndex, data.vote, 'PROPOSAL_VOTE', 'PENDING',
     (_game, _mission, proposal) => proposal.votes,
     (secretVotes) => secretVotes.proposal).then(function() {
     return db.runTransaction(function(txn) {
@@ -678,8 +702,14 @@ export function voteTeam(data: VoteData, uid: string): Promise<void> {
         txn.get(lobbyDocRef),
         txn.get(secretDocRef)]).then(function([lobbyDoc, secretDoc]) {
         const game = lobbyDoc.get('game') as Game;
-        const mission = game.missions[data.mission];
-        const proposal = mission.proposals[data.proposal];
+        if (!game || !Array.isArray(game.missions) || missionIndex >= game.missions.length) {
+          throw new AvalonError(400, 'Mission not found');
+        }
+        const mission = game.missions[missionIndex];
+        if (!Array.isArray(mission.proposals) || proposalIndex >= mission.proposals.length) {
+          throw new AvalonError(400, 'Proposal not found');
+        }
+        const proposal = mission.proposals[proposalIndex];
         const votes = secretDoc.get('votes') as SecretVotes;
 
         if (proposal.state != 'PENDING') {
@@ -696,7 +726,7 @@ export function voteTeam(data: VoteData, uid: string): Promise<void> {
         if (proposal.votes.length < Math.floor(game.players.length / 2) + 1) {
           proposal.state = 'REJECTED';
 
-          if (data.proposal == 4) {
+          if (proposalIndex == 4) {
             return endGameTxn(txn, lobbyDoc, secretDoc, 'EVIL_WIN', "Five team proposals in a row rejected", { game });
           } else {
             game.phase = 'TEAM_PROPOSAL';
@@ -723,10 +753,10 @@ export function doMission(data: VoteData, uid: string): Promise<void> {
   const missionIndex = Number(data.mission);
   const proposalIndex = Number(data.proposal);
   if (!Number.isInteger(missionIndex) || missionIndex < 0) {
-    throw new AvalonError(`Invalid mission index: ${data.mission}`, 400);
+    throw new AvalonError(400, `Invalid mission index: ${data.mission}`);
   }
   if (!Number.isInteger(proposalIndex) || proposalIndex < 0) {
-    throw new AvalonError(`Invalid proposal index: ${data.proposal}`, 400);
+    throw new AvalonError(400, `Invalid proposal index: ${data.proposal}`);
   }
 
   return recordVote(data.name, uid, data.lobby, missionIndex,


### PR DESCRIPTION
Potential fix for [https://github.com/georgyo/avalon/security/code-scanning/9](https://github.com/georgyo/avalon/security/code-scanning/9)

In general terms, the fix is to prevent untrusted values from being used directly as object property keys on regular, prototypeful objects. For this code, the untrusted values are the mission index and proposal index fields on `VoteData` (coming from `req.body`), and they are used to index into `game.missions[...]` and `votes.mission[...]`. We should restrict these indices to safe, finite values before using them. Since the game logic clearly expects mission and proposal indices (numbers in small ranges), coercing them to numbers and validating them against known bounds will both prevent prototype pollution (because `__proto__` et al. are not valid numbers) and avoid out-of-range accesses.

The best fix with minimal functional change is:

1. In `doMission`, derive *validated numeric* indices from `data.mission` and `data.proposal`.  
   - Convert to integers: `const missionIndex = Number(data.mission); const proposalIndex = Number(data.proposal);`  
   - Check they are finite integers and within valid bounds:  
     - `0 <= missionIndex < game.missions.length`  
     - `0 <= proposalIndex < mission.proposals.length` (once `mission` is known)
2. Use these validated indices everywhere instead of `data.mission` / `data.proposal`:  
   - `const mission = game.missions[missionIndex];`  
   - `const proposal = mission.proposals[proposalIndex];`  
   - `votes.mission[missionIndex]`  
   - `game.missions[missionIndex + 1]` for the next mission.
3. If validation fails at any point, throw an `AvalonError` with an appropriate message and status code (e.g., `400`), similar to other validation in this codebase, so existing consumers receive a structured error instead of silent misbehavior.

These changes all occur in `server/avalon-server.ts` inside the `doMission` function, in and immediately around the shown snippet; no new imports are required, as we only use standard JavaScript functionality and the existing `AvalonError` type.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
