### PR TITLE
Fix lobby buttons to always stack vertically

### DIFF
--- a/client/src/components/LobbySelect.vue
+++ b/client/src/components/LobbySelect.vue
@@ -6,7 +6,7 @@
         label="Your Name" @update:model-value="val => name = val.toUpperCase()" ref='nameTextField' v-model="name" :rules="nameRules" :error-messages='errorMsg' autofocus
         class="lobby-input">
       </v-text-field>
-      <div class="d-flex flex-column flex-sm-row ga-2 lobby-buttons">
+      <div class="d-flex flex-column ga-2 lobby-buttons">
         <v-btn
          :disabled='!name' @click='createLobby()' :loading="isCreatingLobby" block>
           Create Lobby
@@ -19,7 +19,7 @@
    <template v-else>
     <v-text-field ref="lobbyTextField" @update:model-value="val => lobby = val.toUpperCase()" label="Lobby" :error-messages='errorMsg' v-model="lobby" @keyup.enter="joinLobby()"
       class="lobby-input"></v-text-field>
-    <div class="d-flex flex-column flex-sm-row ga-2 lobby-buttons">
+    <div class="d-flex flex-column ga-2 lobby-buttons">
       <v-btn :disabled='!lobby' @click='joinLobby()' :loading="isJoiningLobby" block>
         Join Lobby
       </v-btn>


### PR DESCRIPTION
## Summary
- Remove `flex-sm-row` Vuetify class from both lobby button containers in `LobbySelect.vue`
- Buttons now always stack vertically (`flex-column`) regardless of viewport width, instead of switching to horizontal layout on screens >= 600px

## Test plan
- [ ] Open the lobby select screen on a wide viewport and confirm buttons are stacked vertically
- [ ] Resize to a narrow viewport and confirm buttons remain stacked vertically
- [ ] Verify both button groups (Create/Join and Join/Cancel) behave consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)