### PR TITLE
ci: run the e2e suite against local Firebase emulators

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,3 +35,53 @@ jobs:
 
       - run: nix flake check
       - run: nix build .#
+
+  # End-to-end tests. These run entirely against a throwaway local stack
+  # (Firebase auth + firestore emulators, the API server, and the vite dev
+  # server) -- see tests/e2e-stack.mjs. Nothing here touches the live
+  # avalon.onl API or the production Firebase project.
+  e2e:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: "read"
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      # The Firestore emulator is a Java process.
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      # The emulator jars are downloaded on first use; keep them between runs.
+      - name: Cache Firebase emulators
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/firebase/emulators
+          key: firebase-emulators-${{ runner.os }}
+
+      - name: Install Playwright Firefox
+        run: yarn exec playwright install --with-deps firefox
+
+      - name: Run e2e suite
+        run: yarn test:e2e
+
+      - name: Upload screenshots on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-screenshots
+          path: tests/screenshots/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,34 +48,23 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-
-      - uses: actions/setup-node@v6
+      - uses: NixOS/nix-installer-action@main
+      - uses: Mic92/niks3-action@v1
         with:
-          node-version: 24
+          server-url: https://niks3.fu.io
 
-      # The Firestore emulator is a Java process.
-      - uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 21
-
-      - run: corepack enable
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      # The emulator jars are downloaded on first use; keep them between runs.
+      # `nix run .#e2e` pins the whole toolchain (Node, the JDK the Firestore
+      # emulator needs, and the Playwright browsers) so there's no setup-node /
+      # setup-java / playwright-install dance. The Firestore emulator jar is
+      # still downloaded on first use; keep it between runs.
       - name: Cache Firebase emulators
         uses: actions/cache@v4
         with:
           path: ~/.cache/firebase/emulators
           key: firebase-emulators-${{ runner.os }}
 
-      - name: Install Playwright Firefox
-        run: yarn exec playwright install --with-deps firefox
-
       - name: Run e2e suite
-        run: yarn test:e2e
+        run: nix run .#e2e
 
       - name: Upload screenshots on failure
         if: failure()

--- a/client/src/avalon.ts
+++ b/client/src/avalon.ts
@@ -1,6 +1,6 @@
 import { initializeApp } from 'firebase/app'
-import { getAuth, signOut, signInAnonymously as firebaseSignInAnonymously, sendSignInLinkToEmail, signInWithEmailLink, onAuthStateChanged, type User, type UserCredential } from 'firebase/auth'
-import { getFirestore, doc, onSnapshot, getDoc, type DocumentSnapshot } from 'firebase/firestore'
+import { getAuth, connectAuthEmulator, signOut, signInAnonymously as firebaseSignInAnonymously, sendSignInLinkToEmail, signInWithEmailLink, onAuthStateChanged, type User, type UserCredential } from 'firebase/auth'
+import { getFirestore, connectFirestoreEmulator, doc, onSnapshot, getDoc, type DocumentSnapshot } from 'firebase/firestore'
 import { bindAll, difference, keys, keyBy, values } from 'lodash-es'
 import * as avalonLib from '@avalon/common/avalonlib';
 import {AvalonApi} from './avalon-api-rest';
@@ -21,6 +21,21 @@ const HOSTNAME = window.location.origin + '/';
 const firebaseApp = initializeApp(firebaseConfig);
 const auth = getAuth(firebaseApp);
 const db = getFirestore(firebaseApp);
+
+// Point the SDK at the local Firebase emulators when VITE_USE_EMULATORS is set.
+// This is what lets the e2e suite run against a throwaway local stack instead
+// of the live project. Vite statically replaces import.meta.env at build time,
+// so production bundles drop this branch entirely.
+if (import.meta.env.VITE_USE_EMULATORS === 'true') {
+  const authHost = import.meta.env.VITE_AUTH_EMULATOR_URL || 'http://127.0.0.1:9099';
+  const [firestoreHost, firestorePort] = (
+    import.meta.env.VITE_FIRESTORE_EMULATOR_HOST || '127.0.0.1:9080'
+  ).split(':');
+
+  connectAuthEmulator(auth, authHost, { disableWarnings: true });
+  connectFirestoreEmulator(db, firestoreHost, Number(firestorePort));
+  console.log('Firebase emulators connected:', authHost, firestoreHost + ':' + firestorePort);
+}
 
 function onFirebaseError(err: Error): void {
   console.error(err);

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -15,7 +15,10 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'https://avalon.onl',
+        // Defaults to production so `yarn dev` keeps working against the live
+        // API. The e2e suite sets VITE_API_TARGET to a locally running server
+        // so tests never touch production.
+        target: process.env.VITE_API_TARGET || 'https://avalon.onl',
         changeOrigin: true,
       }
     }

--- a/default.nix
+++ b/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
   offlineCache = yarn-berry_4.fetchYarnBerryDeps {
     inherit (finalAttrs) src;
     missingHashes = ./missing-hashes.json;
-    hash = "sha256-HUtkO5Q4mFpHrPe1kcAdehiz0eKDogMybr5Z0u+SuTQ=";
+    hash = "sha256-2/Cf48ItV2RW48XmC34EAUou/utfzz+H2fFI8oU2x3M=";
   };
 
   nativeBuildInputs = [

--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -15,6 +15,13 @@
     },
     "firestore": {
       "port": "9080"
-    }
+    },
+    "auth": {
+      "port": 9099
+    },
+    "ui": {
+      "enabled": false
+    },
+    "singleProjectMode": true
   }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,43 @@
           # `nix run .#update-deps` — run from the repo root after changing
           # dependencies (yarn.lock). Regenerates missing-hashes.json and
           # rewrites the fetchYarnBerryDeps hash in default.nix in place.
+          # `nix run .#e2e` — bring up the throwaway local stack (Firebase
+          # emulators + API server + vite dev) and run the Playwright e2e suite
+          # against it. Unlike `nix build`, this app runs with network access, so
+          # `yarn install` and the Firestore emulator JAR download work normally;
+          # what Nix pins is the toolchain: Node, the JDK the Firestore emulator
+          # needs, and the Playwright browsers.
+          #
+          # The Playwright browsers come from nixpkgs' playwright-driver (already
+          # patched to find their libraries in the Nix store), so no `apt`/root
+          # `--with-deps` step is needed. This requires the npm `playwright`
+          # version to match playwright-driver's: keep the `playwright` pin in
+          # package.json equal to `pkgs.playwright-driver.version`.
+          e2e = pkgs.writeShellApplication {
+            name = "avalon-e2e";
+            runtimeInputs = [
+              pkgs.nodejs_24
+              pkgs.yarn-berry_4
+              pkgs.jdk_headless
+            ];
+            text = ''
+              driverVer='${pkgs.playwright-driver.version}'
+              pinnedVer="$(node -p "require('./package.json').devDependencies.playwright" 2>/dev/null || echo '?')"
+              if [ "$driverVer" != "$pinnedVer" ]; then
+                echo "error: package.json pins playwright '$pinnedVer' but nixpkgs playwright-driver is '$driverVer'." >&2
+                echo "       The Nix-provided browsers won't match. Align the pin, then update yarn.lock." >&2
+                exit 1
+              fi
+
+              export PLAYWRIGHT_BROWSERS_PATH='${pkgs.playwright-driver.browsers}'
+              export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+              export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
+
+              yarn install --immutable
+              exec yarn test:e2e
+            '';
+          };
+
           update-deps = pkgs.writeShellApplication {
             name = "update-deps";
             runtimeInputs = [ pkgs.yarn-berry_4.yarn-berry-fetcher ];
@@ -64,6 +101,12 @@
 
               };
             };
+          };
+
+          apps.e2e = {
+            type = "app";
+            program = "${e2e}/bin/avalon-e2e";
+            meta.description = "Run the Playwright e2e suite against a throwaway local stack with a Nix-pinned toolchain";
           };
 
           apps.update-deps = {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint": "^10.7.0",
     "eslint-plugin-vue": "^10.10.0",
     "globals": "^17.7.0",
-    "playwright": "^1.61.1",
+    "playwright": "1.60.0",
     "postcss": "^8.5.21",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.65.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "admin": "yarn workspace @avalon/server tsx admin.ts",
     "test": "node tests/e2e-flow.mjs",
     "test:browser": "node tests/e2e-browser.mjs",
-    "test:game": "node tests/e2e-full-game.mjs"
+    "test:game": "node tests/e2e-full-game.mjs",
+    "test:e2e": "node tests/e2e-stack.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/server/firebaseKey.ts
+++ b/server/firebaseKey.ts
@@ -6,15 +6,29 @@ import { initializeApp, cert } from 'firebase-admin/app';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-let serviceAccount: Record<string, unknown>;
+// When the Firebase emulators are running, the Admin SDK talks to them over
+// plain HTTP and never validates credentials, so there is no service account
+// to load. The SDK picks the emulators up from these env vars on its own; all
+// we have to do is skip the cert() path and name the project.
+const usingEmulators = Boolean(
+  process.env.FIRESTORE_EMULATOR_HOST || process.env.FIREBASE_AUTH_EMULATOR_HOST
+);
 
-if (process.env.FIREBASE_KEY) {
-  serviceAccount = JSON.parse(process.env.FIREBASE_KEY);
+if (usingEmulators) {
+  initializeApp({
+    projectId: process.env.GCLOUD_PROJECT || 'georgyo-avalon'
+  });
 } else {
-  const keyFile = process.env.FIREBASE_KEY_FILE || path.join(__dirname, 'firebase-key.json');
-  serviceAccount = JSON.parse(fs.readFileSync(keyFile, 'utf8'));
-}
+  let serviceAccount: Record<string, unknown>;
 
-initializeApp({
-  credential: cert(serviceAccount as Parameters<typeof cert>[0])
-});
+  if (process.env.FIREBASE_KEY) {
+    serviceAccount = JSON.parse(process.env.FIREBASE_KEY);
+  } else {
+    const keyFile = process.env.FIREBASE_KEY_FILE || path.join(__dirname, 'firebase-key.json');
+    serviceAccount = JSON.parse(fs.readFileSync(keyFile, 'utf8'));
+  }
+
+  initializeApp({
+    credential: cert(serviceAccount as Parameters<typeof cert>[0])
+  });
+}

--- a/tests/e2e-stack.mjs
+++ b/tests/e2e-stack.mjs
@@ -1,0 +1,251 @@
+// Brings up a throwaway local Avalon stack and runs the e2e suite against it.
+//
+//   Firebase emulators (auth :9099, firestore :9080)
+//        ^                      ^
+//        |                      |
+//   API server :8001 <---- /api proxy ---- vite dev :5173 <---- Playwright
+//
+// Nothing here talks to the live project: the client is built with
+// VITE_USE_EMULATORS so the Firebase JS SDK is redirected at the emulators,
+// and vite proxies /api at the locally running server instead of avalon.onl.
+//
+// Usage:  node tests/e2e-stack.mjs [test-file ...]
+// Defaults to running every tests/e2e-*.mjs file except this one.
+
+import { spawn } from 'child_process';
+import { createConnection } from 'net';
+import { readdirSync } from 'fs';
+import { dirname, join, basename } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = join(__dirname, '..');
+
+const PROJECT = 'georgyo-avalon';
+const AUTH_PORT = 9099;
+const FIRESTORE_PORT = 9080;
+const SERVER_PORT = 8001;
+const VITE_PORT = 5173;
+
+const emulatorEnv = {
+  GCLOUD_PROJECT: PROJECT,
+  FIREBASE_AUTH_EMULATOR_HOST: `127.0.0.1:${AUTH_PORT}`,
+  FIRESTORE_EMULATOR_HOST: `127.0.0.1:${FIRESTORE_PORT}`,
+};
+
+const children = [];
+let shuttingDown = false;
+
+function run(name, cmd, args, opts = {}) {
+  const child = spawn(cmd, args, {
+    cwd: opts.cwd || repoRoot,
+    env: { ...process.env, ...(opts.env || {}) },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  children.push({ name, child });
+
+  const prefix = (line) => `  [${name}] ${line}`;
+  for (const stream of [child.stdout, child.stderr]) {
+    let buf = '';
+    stream.on('data', (d) => {
+      buf += d.toString();
+      const lines = buf.split('\n');
+      buf = lines.pop();
+      for (const l of lines) if (l.trim()) console.log(prefix(l.trimEnd()));
+    });
+  }
+
+  child.on('exit', (code, signal) => {
+    if (!shuttingDown && code !== 0) {
+      console.error(`\nFAIL: ${name} exited early (code=${code} signal=${signal})`);
+      shutdown(1);
+    }
+  });
+
+  return child;
+}
+
+function connects(host, port) {
+  return new Promise((resolve) => {
+    const sock = createConnection({ host, port });
+    const done = (ok) => { sock.destroy(); resolve(ok); };
+    sock.on('connect', () => done(true));
+    sock.on('error', () => done(false));
+    setTimeout(() => done(false), 1000);
+  });
+}
+
+// Vite binds "localhost", which on a dual-stack host resolves to ::1, while the
+// emulators and the API server bind 127.0.0.1. Probe both families and remember
+// which one answered so later HTTP requests use a reachable address.
+const reachableHost = {};
+async function portOpen(port) {
+  for (const host of ['127.0.0.1', '::1']) {
+    if (await connects(host, port)) {
+      reachableHost[port] = host === '::1' ? '[::1]' : host;
+      return true;
+    }
+  }
+  return false;
+}
+
+async function waitForPort(port, label, timeoutMs = 180000) {
+  const deadline = Date.now() + timeoutMs;
+  process.stdout.write(`==> waiting for ${label} on :${port} `);
+  while (Date.now() < deadline) {
+    if (await portOpen(port)) {
+      console.log('ready');
+      return;
+    }
+    process.stdout.write('.');
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  console.log('');
+  throw new Error(`${label} did not come up on port ${port} within ${timeoutMs}ms`);
+}
+
+// Fetch the app shell and its entry module until both come back cleanly, so the
+// first Playwright navigation isn't the thing that triggers a dep re-bundle.
+async function warmUp(timeoutMs = 60000) {
+  const base = `http://${reachableHost[VITE_PORT] || '127.0.0.1'}:${VITE_PORT}`;
+  const deadline = Date.now() + timeoutMs;
+  process.stdout.write('==> warming up vite ');
+  while (Date.now() < deadline) {
+    try {
+      const html = await fetch(`${base}/`).then((r) => (r.ok ? r.text() : null));
+      const entry = html && html.match(/src="(\/src\/[^"]+)"/)?.[1];
+      if (entry) {
+        const res = await fetch(base + entry);
+        if (res.ok && (res.headers.get('content-type') || '').includes('javascript')) {
+          console.log('ready');
+          return;
+        }
+      }
+    } catch {
+      // server not answering yet
+    }
+    process.stdout.write('.');
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  console.log('');
+  throw new Error('vite dev server never served a usable entry module');
+}
+
+async function shutdown(code) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log('\n==> shutting down local stack');
+  for (const { name, child } of children.reverse()) {
+    if (child.exitCode === null) {
+      console.log(`  stopping ${name}`);
+      child.kill('SIGTERM');
+    }
+  }
+  // Give them a moment to exit cleanly, then force.
+  await new Promise((r) => setTimeout(r, 2000));
+  for (const { child } of children) if (child.exitCode === null) child.kill('SIGKILL');
+  process.exit(code);
+}
+
+process.on('SIGINT', () => shutdown(130));
+process.on('SIGTERM', () => shutdown(143));
+
+async function main() {
+  const requested = process.argv.slice(2);
+  const testFiles = requested.length
+    ? requested
+    : readdirSync(__dirname)
+        .filter((f) => f.startsWith('e2e-') && f.endsWith('.mjs') && f !== basename(__filename))
+        .sort()
+        .map((f) => join(__dirname, f));
+
+  console.log('==> tests to run:');
+  for (const f of testFiles) console.log(`      ${basename(f)}`);
+
+  // 0. @avalon/common resolves to dist/, so it has to be compiled before the
+  //    server or the client can import it.
+  console.log('\n==> building @avalon/common');
+  await new Promise((resolve, reject) => {
+    const b = spawn('yarn', ['build:common'], { cwd: repoRoot, env: process.env, stdio: 'inherit' });
+    b.on('exit', (c) => (c === 0 ? resolve() : reject(new Error(`yarn build:common failed (exit ${c})`))));
+  });
+
+  // 1. Firebase emulators (auth + firestore). Needs a JDK on PATH.
+  console.log('\n==> starting Firebase emulators');
+  run('emulators', 'yarn', [
+    'workspace', 'functions', 'exec',
+    'firebase', 'emulators:start',
+    '--only', 'auth,firestore',
+    '--project', PROJECT,
+  ], { cwd: join(repoRoot, 'firebase') });
+
+  await waitForPort(FIRESTORE_PORT, 'firestore emulator');
+  await waitForPort(AUTH_PORT, 'auth emulator');
+
+  // 2. API server, pointed at the emulators (no service account needed).
+  console.log('\n==> starting API server');
+  run('server', 'yarn', ['workspace', '@avalon/server', 'start'], {
+    env: { ...emulatorEnv, PORT: String(SERVER_PORT) },
+  });
+  await waitForPort(SERVER_PORT, 'api server');
+
+  // 3. Vite dev server, proxying /api at the local server and building the
+  //    client with the emulator hooks switched on.
+  const viteEnv = {
+    VITE_API_TARGET: `http://127.0.0.1:${SERVER_PORT}`,
+    VITE_USE_EMULATORS: 'true',
+    VITE_AUTH_EMULATOR_URL: `http://127.0.0.1:${AUTH_PORT}`,
+    VITE_FIRESTORE_EMULATOR_HOST: `127.0.0.1:${FIRESTORE_PORT}`,
+  };
+
+  // Pre-bundle deps up front. Otherwise the dev server starts optimizing on the
+  // first request and the in-flight module graph 404s underneath the browser,
+  // which surfaces as spurious "disallowed MIME type" errors in the tests.
+  console.log('\n==> pre-bundling client dependencies');
+  await new Promise((resolve, reject) => {
+    const opt = spawn('yarn', ['workspace', '@avalon/client', 'exec', 'vite', 'optimize', '--force'], {
+      cwd: repoRoot,
+      env: { ...process.env, ...viteEnv },
+      stdio: 'inherit',
+    });
+    opt.on('exit', (c) => (c === 0 ? resolve() : reject(new Error(`vite optimize failed (exit ${c})`))));
+  });
+
+  console.log('\n==> starting vite dev server');
+  run('vite', 'yarn', ['workspace', '@avalon/client', 'dev', '--port', String(VITE_PORT), '--strictPort'], {
+    env: viteEnv,
+  });
+  await waitForPort(VITE_PORT, 'vite dev server');
+  await warmUp();
+
+  // 4. Run each test against the stack.
+  let failed = 0;
+  for (const file of testFiles) {
+    const name = basename(file);
+    console.log(`\n${'='.repeat(60)}\n==> ${name}\n${'='.repeat(60)}`);
+    const code = await new Promise((resolve) => {
+      const t = spawn(process.execPath, [file], {
+        cwd: repoRoot,
+        env: { ...process.env, ...emulatorEnv },
+        stdio: 'inherit',
+      });
+      t.on('exit', (c) => resolve(c ?? 1));
+    });
+    if (code === 0) {
+      console.log(`\n==> ${name}: PASS`);
+    } else {
+      console.error(`\n==> ${name}: FAIL (exit ${code})`);
+      failed++;
+    }
+  }
+
+  console.log(`\n${'='.repeat(60)}`);
+  console.log(failed === 0 ? `All ${testFiles.length} e2e test(s) passed` : `${failed} of ${testFiles.length} e2e test(s) failed`);
+  await shutdown(failed === 0 ? 0 : 1);
+}
+
+main().catch(async (err) => {
+  console.error('\nFAIL:', err.message);
+  await shutdown(1);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2897,7 +2897,7 @@ __metadata:
     eslint: "npm:^10.7.0"
     eslint-plugin-vue: "npm:^10.10.0"
     globals: "npm:^17.7.0"
-    playwright: "npm:^1.61.1"
+    playwright: "npm:1.60.0"
     postcss: "npm:^8.5.21"
     typescript: "npm:^6.0.3"
     typescript-eslint: "npm:^8.65.0"
@@ -7227,27 +7227,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.61.1":
-  version: 1.61.1
-  resolution: "playwright-core@npm:1.61.1"
+"playwright-core@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright-core@npm:1.60.0"
   bin:
     playwright-core: cli.js
-  checksum: 10/b0e7b1d4de7ca6c1a57eb88f1709609a8b7637092f149e703d84d6c8e01835992ec5ca26b86f1a32fb5f5bc1aad042c3ae27311e131b3dda8a27824a543eb3c7
+  checksum: 10/66c0f83d627e673261c848dd6fe1f2856d5b5b6859268acb61a45c00f5bf926e596a351a9c481a3a4e82a45022c7c6b5d99ebc3906fc6876ac582ed6f7e16190
   languageName: node
   linkType: hard
 
-"playwright@npm:^1.61.1":
-  version: 1.61.1
-  resolution: "playwright@npm:1.61.1"
+"playwright@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright@npm:1.60.0"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.61.1"
+    playwright-core: "npm:1.60.0"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 10/0cd1a8a7e106202e785450763973bf326d4aa112ed195bbd78b17af43dcfd12e29bc8204ae61c88f748dd0f2bdf69a7827bc3bbf8c1ec4c71b8e35586e05f13c
+  checksum: 10/8569770637ee35d08cca3b53a5b56c21e9236bd1ac4718456d5988fb8acd51c5b3cc2cf90748363a36199529e870a9b6c68d6fc9e19571261cd867005d6331c1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds the e2e suite to CI, running against a throwaway local stack.

## Why this isn't just a CI wiring change

The tests could not be added as they were. All three target the vite dev server, and `client/vite.config.js` proxied `/api` at `https://avalon.onl`. Putting them in CI as-is would have meant **every PR creating real anonymous auth users, real lobbies and real games in the production `georgyo-avalon` project** — and going red whenever production had an unrelated blip.

There was a second, quieter problem: because `/api` went to production, **the e2e suite never exercised this repo's server code at all**. A server-side regression could not fail it. `e2e-flow.mjs` even swallows API failures — it filters `AxiosError` / `Failed to fetch` out of its error check and logs `NOTE: API error from production server (not a client code issue)` while still exiting 0.

So this PR closes a real coverage gap rather than relocating the tests.

## The local stack

```
Firebase emulators (auth :9099, firestore :9080)
     ^                      ^
     |                      |
API server :8001 <-- /api proxy -- vite dev :5173 <-- Playwright
```

`tests/e2e-stack.mjs` (`yarn test:e2e`) builds `@avalon/common`, brings each component up in order, waits for it, pre-bundles client deps, runs the tests, and tears everything down. Run it with no arguments for the whole suite, or pass specific test files.

## Changes

| File | Change |
|---|---|
| `server/firebaseKey.ts` | Skip `cert()` when `FIRESTORE_EMULATOR_HOST` / `FIREBASE_AUTH_EMULATOR_HOST` is set — the Admin SDK talks to emulators over plain HTTP and doesn't validate credentials, so there's no key to load. Production path untouched. |
| `client/src/avalon.ts` | `connectAuthEmulator` / `connectFirestoreEmulator` when `VITE_USE_EMULATORS=true` |
| `client/vite.config.js` | Proxy target from `VITE_API_TARGET`, defaulting to `https://avalon.onl` so `yarn dev` is unchanged |
| `firebase/firebase.json` | Add the auth emulator, disable the emulator UI, enable `singleProjectMode` |
| `.github/workflows/main.yml` | New `e2e` job |
| `tests/e2e-stack.mjs` | New orchestrator |

## Production is unaffected

Vite statically replaces `import.meta.env` at build time, so the emulator branch is dead-code-eliminated. Verified after `yarn build` — **zero** references to `connectAuthEmulator`, the emulator ports, or the emulator log line in `server/dist`. The `yarn dev` proxy default and the production `cert()` credential path are both unchanged.

## The CI job

Installs a JDK (the Firestore emulator is a Java process), caches the emulator jars between runs, installs Playwright Firefox, runs the suite, and uploads screenshots as an artifact on failure.

## Verification

Run locally under `nix shell nixpkgs#jdk` on this branch, rebased onto current master:

```
==> e2e-browser.mjs: PASS
==> e2e-flow.mjs: PASS
==> e2e-full-game.mjs: PASS
All 3 e2e test(s) passed          (107s)
```

The flow test now drives our own `/createLobby` and `/leaveLobby`, and the full-game test plays a complete 5-player game — roles, missions, votes, assassination, admin handoff — through this build of the server. Server logs are interleaved into the output, so you can see the requests actually hitting local code.

Also re-ran: server typecheck, all four workspace lints, `yarn build`, `nix build .#`, `nix flake check`, `yarn install --immutable`, and a boot smoke test of the production credential path (static 200, unauthenticated API 401).

## Follow-up worth considering

CI still doesn't run lint or typecheck — `build` only runs `nix flake check` + `nix build`, and while the Nix build does run `yarn workspace @avalon/server typecheck`, client and functions lint are not covered. Happy to add that separately.
